### PR TITLE
fix: caching problem with missing await

### DIFF
--- a/molstar-extension/src/extensions/volumes-and-segmentations/entry-root.ts
+++ b/molstar-extension/src/extensions/volumes-and-segmentations/entry-root.ts
@@ -694,7 +694,7 @@ export class VolsegEntryData extends PluginBehavior.WithSubscribers<VolsegEntryP
     async preloadVolumeTimeframesData() {
         const timeInfo = this.metadata.value!.raw.grid.volumes.time_info;
         const channelIds = this.metadata.value!.raw.grid.volumes.channel_ids;
-        this.loadRawChannelsData(timeInfo, channelIds);
+        await this.loadRawChannelsData(timeInfo, channelIds);
     }
 
     preloadSegmentationTimeframesDataFromFile() {
@@ -768,7 +768,7 @@ export class VolsegEntryData extends PluginBehavior.WithSubscribers<VolsegEntryP
         if (this.metadata.value!.raw.grid.segmentation_lattices) {
             const segmentationIds = this.metadata.value!.raw.grid.segmentation_lattices.segmentation_ids;
             const timeInfoMapping = this.metadata.value!.raw.grid.segmentation_lattices.time_info;
-            this.loadRawLatticeSegmentationData(timeInfoMapping, segmentationIds);
+            await this.loadRawLatticeSegmentationData(timeInfoMapping, segmentationIds);
         }
     }
 
@@ -776,7 +776,7 @@ export class VolsegEntryData extends PluginBehavior.WithSubscribers<VolsegEntryP
         if (this.metadata.value!.raw.grid.segmentation_meshes) {
             const segmentationIds = this.metadata.value!.raw.grid.segmentation_meshes.segmentation_ids;
             const timeInfoMapping = this.metadata.value!.raw.grid.segmentation_meshes.time_info;
-            this.loadRawMeshSegmentationData(timeInfoMapping, segmentationIds);
+            await this.loadRawMeshSegmentationData(timeInfoMapping, segmentationIds);
         }
     }
 
@@ -784,7 +784,7 @@ export class VolsegEntryData extends PluginBehavior.WithSubscribers<VolsegEntryP
         if (this.metadata.value!.raw.grid.geometric_segmentation) {
             const segmentationIds = this.metadata.value!.raw.grid.geometric_segmentation.segmentation_ids;
             const timeInfoMapping = this.metadata.value!.raw.grid.geometric_segmentation.time_info;
-            this.loadRawShapePrimitiveData(timeInfoMapping, segmentationIds);
+            await this.loadRawShapePrimitiveData(timeInfoMapping, segmentationIds);
         }
     }
 


### PR DESCRIPTION
If the preload functions aren't awaited the data gets refetched in the transformers (eg. [ProjectVolumeData](https://github.com/molstar/molstar-volseg/blob/6337b83a16e8c06cfd56e5bf7bb8bab3f295bdee/molstar-extension/src/extensions/volumes-and-segmentations/transformers.ts#L59)).

Loading EMPIAR-10070
Without await
![Screenshot from 2024-08-09 14-11-55](https://github.com/user-attachments/assets/3747e60a-8275-4b10-bf26-bba2f5f45e38)

With await
![Screenshot from 2024-08-09 14-11-26](https://github.com/user-attachments/assets/8f3e452b-c2d5-4264-b1ec-b356a8eb7e3f)
